### PR TITLE
Updating to version 2.0.2 to fix problem with npm

### DIFF
--- a/src/NuGet/ColonesExchangeRate/ColonesExchangeRate.csproj
+++ b/src/NuGet/ColonesExchangeRate/ColonesExchangeRate.csproj
@@ -12,8 +12,8 @@
     <PackageTags>colones; dollars; euros; currency-exchange; exchange-rate; costa-rica; CRC;</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/dsanchezcr/ColonesExchangeRate</PackageProjectUrl>
-    <Version>2.0.1</Version>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <Version>2.0.2</Version>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
     <Description>Currency conversion from Colones (Costa Rica - CRC ₡) to Dollars (United States - USD $) and Euros (European Union - EUR €). It consumes the exchange rate API from Ministerio de Hacienda de Costa Rica.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/npm/package.json
+++ b/src/npm/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@dsanchezcr/colonesexchangerate",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "description": "Currency conversion from Colones (Costa Rica - CRC ₡) to Dollars (United States - USD $) and Euros (European Union - EUR €). It consumes the exchange rate API from Ministerio de Hacienda de Costa Rica.",
-  "main": "ColonesExchangeRate.mjs",
+  "main": "colonesexchangerate.mjs",
   "scripts": {
     "test": "node colonesexchangerate.test.js",
     "build": "echo 'No build step required'"


### PR DESCRIPTION
Fixing issue with NPM package because the main is pointing to the .mjs file with capitals which is causing an issue in non-Windows OS.