### PR TITLE
Use NuGet/login in CI and bump dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - '.github/**'
   workflow_dispatch:
+
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -88,15 +88,13 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
-    - name: Get NuGet OIDC token
-      id: nuget-oidc
-      run: |
-        token=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://NuGetTrustedPublisher" | jq -r '.value')
-        echo "::add-mask::$token"
-        echo "token=$token" >> "$GITHUB_OUTPUT"
+    - name: NuGet Trusted Publishing login
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: dsanchezcr
     - name: Publish to NuGet.org
-      run: dotnet nuget push **/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-oidc.outputs.token }}
+      run: dotnet nuget push **/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
     - name: Authenticating to GitHub Packages
       run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/dsanchezcr/index.json"
     - name: Publish to GitHub Packages
@@ -111,6 +109,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
     - uses: actions/checkout@v6
     - name: Set up Node.js for npmjs.com

--- a/src/NuGet/ColonesExchangeRate.Tests/ColonesExchangeRate.Tests.csproj
+++ b/src/NuGet/ColonesExchangeRate.Tests/ColonesExchangeRate.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/NuGet/ColonesExchangeRate.Tests/ColonesExchangeRate.Tests.csproj
+++ b/src/NuGet/ColonesExchangeRate.Tests/ColonesExchangeRate.Tests.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/NuGet/ColonesExchangeRate/ColonesExchangeRate.csproj
+++ b/src/NuGet/ColonesExchangeRate/ColonesExchangeRate.csproj
@@ -33,6 +33,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Replace manual OIDC token retrieval with NuGet/login@v1 in the GitHub Actions workflow and use its NUGET_API_KEY output for dotnet nuget push; add packages: write permission. Add permissions: read-all to the CodeQL workflow. Update test project packages (xunit.runner.visualstudio 2.8.2 -> 3.1.5, coverlet.collector 6.0.4 -> 8.0.0) and bump System.Text.Json in the main project (8.0.6 -> 10.0.3). These changes simplify NuGet authentication and bring dependencies up to newer supported versions.